### PR TITLE
Lightncandy had 1.0.0 release, time to rely on it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3.0",
         "pimple/pimple": "~3.0",
-        "zordius/lightncandy": "dev-master"
+        "zordius/lightncandy": "^1.0"
     },
     "require-dev": {
         "slim/slim": "^3.0.0",


### PR DESCRIPTION
It would also be good to get rid of  those `.git` folders in our `vendor` dir)